### PR TITLE
Exit main.py with the exit code provided from pytest.main

### DIFF
--- a/manga109tools/main.py
+++ b/manga109tools/main.py
@@ -1,6 +1,7 @@
 import argparse
 from pathlib import Path
 import pytest
+import sys
 
 
 def parse_args() -> argparse.Namespace:
@@ -35,7 +36,8 @@ def main():
             args.exception_path.as_posix(),
         ]
 
-        pytest.main(pytest_args)
+        exit_code = pytest.main(pytest_args)
+        sys.exit(exit_code)
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
Currently, main.py (the tool `manga109tools`) always exits with exit status 0 in a shell, even if some of the pytest results fail. This is since `pytest.main()` is returning an exit code (`pytest.ExitCode`) but its value is unused.

This pull request fixes this so that main.py always exits with `exit(exit_code)` where `exit_code` is the return value from `pytest.main()`. When the pytest passes without failures, this results in `exit(0)` without errors.

This is particularly useful (or necessary) when integrating `manga109tools` within a Makefile, or when you want to use the exit status to check the pytest results within a shellscript.